### PR TITLE
Removed verison line

### DIFF
--- a/v2.0.3/docker-compose.yml
+++ b/v2.0.3/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.0.4/docker-compose.yml
+++ b/v2.0.4/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.1.0/docker-compose.yml
+++ b/v2.1.0/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.1.1/docker-compose.yml
+++ b/v2.1.1/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.1.2/docker-compose.yml
+++ b/v2.1.2/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.2.0/docker-compose.yml
+++ b/v2.2.0/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.3.0/docker-compose.yml
+++ b/v2.3.0/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.3.1/docker-compose.yml
+++ b/v2.3.1/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.4.0/docker-compose.yml
+++ b/v2.4.0/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.5.0/docker-compose.yml
+++ b/v2.5.0/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.5.1/docker-compose.yml
+++ b/v2.5.1/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v2.6.4-mssql/docker-compose.yml
+++ b/v2.6.4-mssql/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: localmssql:latest

--- a/v2.6.4/docker-compose.yml
+++ b/v2.6.4/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v21.06.0/docker-compose.yml
+++ b/v21.06.0/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v21.10.0/docker-compose.yml
+++ b/v21.10.0/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v22.10.0/docker-compose.yml
+++ b/v22.10.0/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v22.10.1/docker-compose.yml
+++ b/v22.10.1/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v22.10.11/docker-compose.yml
+++ b/v22.10.11/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v23.10.3-postgres/docker-compose.yml
+++ b/v23.10.3-postgres/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   db:
     build:

--- a/v23.10.3-redis-and-postgres/docker-compose.yml
+++ b/v23.10.3-redis-and-postgres/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   db:
     build:

--- a/v23.10.3/docker-compose.yml
+++ b/v23.10.3/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   db:
     image: postgres:11

--- a/v23.10.4-simple-redis/docker-compose.yml
+++ b/v23.10.4-simple-redis/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   planet9:
     build:


### PR DESCRIPTION
Removed version 3.1, 3.8 and 3.5, as version is deprecated since Docker Compose version 2.25.0